### PR TITLE
Correcting ref to action repo.

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -14,18 +14,18 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Statick
-        uses: sscpac/statick-action
+        uses: sscpac/statick-action@main
         with:
           profile: self_check.yaml
 
       - name: Statick Markdown
-        uses: sscpac/statick-action
+        uses: sscpac/statick-action@main
         with:
           config: md-config.yaml
           profile: md-profile.yaml
 
       - name: Statick Tooling
-        uses: sscpac/statick-action
+        uses: sscpac/statick-action@main
         with:
           config: tooling-config.yaml
           profile: tooling-profile.yaml


### PR DESCRIPTION
My edits right before merge to correct the Action URL were bad.  I didn't know that a branch or version tag is required.  I'm using 'main' here for now.  Once we make an official release to the Action marketplace, these will likely be changed from a branch to a version.