### PR TITLE
Simplify docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ LABEL "homepage"="https://github.com/sscpac/statick-action"
 LABEL "maintainer"="Thomas Denewiler <tdenewiler@gmail.com>"
 
 COPY entrypoint.sh /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Use existing Docker image created and pushed from the main statick repo, reduce runtime for the action significantly.